### PR TITLE
feat(padder): implement Source trait for &[T]

### DIFF
--- a/benches/bench_main.rs
+++ b/benches/bench_main.rs
@@ -7,4 +7,5 @@ criterion_main! {
     benchmarks::pad_whitespace_rightalign::pads,
     benchmarks::pad_wrapper_hyphen_rightalign::pads,
     benchmarks::pad_wrapper_whitespace_leftalign::pads,
+    benchmarks::pad_and_push_to_buffer_wrapper_whitespace_center::pads,
 }

--- a/benches/benchmarks/mod.rs
+++ b/benches/benchmarks/mod.rs
@@ -1,4 +1,5 @@
 pub mod format_whitespace_leftalign;
+pub mod pad_and_push_to_buffer_wrapper_whitespace_center;
 pub mod pad_whitespace_leftalign;
 pub mod pad_whitespace_rightalign;
 pub mod pad_wrapper_hyphen_rightalign;

--- a/benches/benchmarks/pad_and_push_to_buffer_wrapper_whitespace_center.rs
+++ b/benches/benchmarks/pad_and_push_to_buffer_wrapper_whitespace_center.rs
@@ -5,9 +5,17 @@ pub fn pad_and_push_to_buffer_wrapper_whitespace_10_center(c: &mut Criterion) {
     let width: usize = 10;
     let mut buffer: Vec<u8> = Vec::with_capacity(width);
     c.bench_function("pad&push wrapper ws 10 center", |b| {
-        b.iter(|| black_box({
-            pad_and_push_to_buffer("hej".as_bytes(), width, Alignment::Center, Symbol::Whitespace, &mut buffer);
-        }))
+        b.iter(|| {
+            black_box({
+                pad_and_push_to_buffer(
+                    "hej".as_bytes(),
+                    width,
+                    Alignment::Center,
+                    Symbol::Whitespace,
+                    &mut buffer,
+                );
+            })
+        })
     });
 }
 
@@ -15,9 +23,17 @@ pub fn pad_and_push_to_buffer_wrapper_whitespace_100_center(c: &mut Criterion) {
     let width: usize = 100;
     let mut buffer: Vec<u8> = Vec::with_capacity(width);
     c.bench_function("pad&push wrapper ws 100 center", |b| {
-        b.iter(|| black_box({
-            pad_and_push_to_buffer("uga78r9eguerbknma bba re7".as_bytes(), width, Alignment::Center, Symbol::Whitespace, &mut buffer);
-        }))
+        b.iter(|| {
+            black_box({
+                pad_and_push_to_buffer(
+                    "uga78r9eguerbknma bba re7".as_bytes(),
+                    width,
+                    Alignment::Center,
+                    Symbol::Whitespace,
+                    &mut buffer,
+                );
+            })
+        })
     });
 }
 

--- a/benches/benchmarks/pad_and_push_to_buffer_wrapper_whitespace_center.rs
+++ b/benches/benchmarks/pad_and_push_to_buffer_wrapper_whitespace_center.rs
@@ -1,0 +1,66 @@
+use criterion::{black_box, criterion_group, Criterion};
+use padder::*;
+
+pub fn pad_and_push_to_buffer_wrapper_whitespace_10_center(c: &mut Criterion) {
+    let width: usize = 10;
+    let mut buffer: Vec<u8> = Vec::with_capacity(width);
+    c.bench_function("pad&push wrapper ws 10 center", |b| {
+        b.iter(|| black_box({
+            pad_and_push_to_buffer("hej".as_bytes(), width, Alignment::Center, Symbol::Whitespace, &mut buffer);
+        }))
+    });
+}
+
+pub fn pad_and_push_to_buffer_wrapper_whitespace_100_center(c: &mut Criterion) {
+    let width: usize = 100;
+    let mut buffer: Vec<u8> = Vec::with_capacity(width);
+    c.bench_function("pad&push wrapper ws 100 center", |b| {
+        b.iter(|| black_box({
+            pad_and_push_to_buffer("uga78r9eguerbknma bba re7".as_bytes(), width, Alignment::Center, Symbol::Whitespace, &mut buffer);
+        }))
+    });
+}
+
+pub fn pad_and_push_to_buffer_wrapper_whitespace_1000_center(c: &mut Criterion) {
+    let width: usize = 1000;
+    let mut buffer: Vec<u8> = Vec::with_capacity(width);
+    c.bench_function("pad&push wrapper ws 1000 center", |b| {
+        b.iter(|| {
+            black_box({
+                pad_and_push_to_buffer(
+                    "Undercity is a cool capital...".as_bytes(),
+                    width,
+                    Alignment::Left,
+                    Symbol::Whitespace,
+                    &mut buffer,
+                )
+            })
+        })
+    });
+}
+
+pub fn pad_and_push_to_buffer_wrapper_whitespace_10000_center(c: &mut Criterion) {
+    let width: usize = 10000;
+    let mut buffer: Vec<u8> = Vec::with_capacity(width);
+    c.bench_function("pad&push wrapper ws 10000 center", |b| {
+        b.iter(|| {
+            black_box({
+                pad_and_push_to_buffer(
+                    "¤)(åäöåa this is a very long string... xd".as_bytes(),
+                    width,
+                    Alignment::Left,
+                    Symbol::Whitespace,
+                    &mut buffer,
+                )
+            })
+        })
+    });
+}
+
+criterion_group!(
+    pads,
+    pad_and_push_to_buffer_wrapper_whitespace_10_center,
+    pad_and_push_to_buffer_wrapper_whitespace_100_center,
+    pad_and_push_to_buffer_wrapper_whitespace_1000_center,
+    pad_and_push_to_buffer_wrapper_whitespace_10000_center,
+);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,7 +140,7 @@ impl From<Symbol> for &[u8] {
 pub trait Source: fmt::Debug {
     type Buffer;
     type Output;
-    
+
     /// Slice the source to fit the target width and return it as the defined output type.
     ///
     /// This function is called whenever a call to [`pad`] is attempted but the
@@ -229,7 +229,7 @@ where
             Alignment::Right => self[(self.len() - width)..].to_vec(),
             Alignment::Center => {
                 self[(self.len() / 2 - width / 2)..(self.len() / 2 + width / 2)].to_vec()
-            },
+            }
         }
     }
 
@@ -256,12 +256,12 @@ where
     }
 
     fn pad_and_push_to_buffer(
-            &self,
-            width: usize,
-            mode: Alignment,
-            symbol: Symbol,
-            buffer: &mut Self::Buffer,
-        ) {
+        &self,
+        width: usize,
+        mode: Alignment,
+        symbol: Symbol,
+        buffer: &mut Self::Buffer,
+    ) {
         let padded: Self::Output = self.pad(width, mode, symbol);
         buffer.extend_from_slice(&padded);
     }


### PR DESCRIPTION
Can now use arbitrary slice of types as Source when padding, given that T implements From<Symbol>.